### PR TITLE
[lg-1] Add file appender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 *.iml
 target/
+logs/

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,3 +11,8 @@ db:
 
 movie:
   randomCount: 3
+
+logger:
+  fileName: movieland
+  logLevelFile: DEBUG
+  logLevelConsole: DEBUG

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,33 @@
+<configuration>
+    <property resource="application.yml" />
+
+    <appender name="colorAppender" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${logLevelConsole}</level>
+        </filter>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d %green([%thread]) %highlight(%level) %logger{50} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="rollingFileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/${fileName}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>logs/${fileName}-%d{yyyy-MM-dd}.log.%i</fileNamePattern>
+            <maxFileSize>5MB</maxFileSize>
+            <maxHistory>90</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${logLevelFile}</level>
+        </filter>
+        <encoder>
+            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="trace">
+        <appender-ref ref="colorAppender" />
+        <appender-ref ref="rollingFileAppender" />
+    </root>
+</configuration>


### PR DESCRIPTION
Configure file appender for logback.
1. All logs, starting from level DEBUG in your application, should be stored in file.
2. For file name, use next pattern:
- current log: movieland.log
- previous logs: movieland-[yyyy-MM-dd].log[.log_number], for example:
movieland-2017-10-15.log.0 - for first log file which was published on 2017-10-15
3. Maximum size of log file is 5mb.