### PR TITLE
[b-7] Currency convertion

### DIFF
--- a/src/main/java/com/filk/dao/MovieDao.java
+++ b/src/main/java/com/filk/dao/MovieDao.java
@@ -1,7 +1,7 @@
 package com.filk.dao;
 
 import com.filk.entity.Movie;
-import com.filk.entity.RequestParameters;
+import com.filk.util.RequestParameters;
 
 import java.util.List;
 

--- a/src/main/java/com/filk/dao/jdbc/JdbcMovieDao.java
+++ b/src/main/java/com/filk/dao/jdbc/JdbcMovieDao.java
@@ -3,7 +3,7 @@ package com.filk.dao.jdbc;
 import com.filk.dao.MovieDao;
 import com.filk.dao.jdbc.mapper.MovieRowMapper;
 import com.filk.entity.Movie;
-import com.filk.entity.RequestParameters;
+import com.filk.util.RequestParameters;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;

--- a/src/main/java/com/filk/dto/CurrencyRateNbuDto.java
+++ b/src/main/java/com/filk/dto/CurrencyRateNbuDto.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CurrencyRateNbuDto {
     @JsonProperty("cc")

--- a/src/main/java/com/filk/dto/CurrencyRateNbuDto.java
+++ b/src/main/java/com/filk/dto/CurrencyRateNbuDto.java
@@ -1,0 +1,16 @@
+package com.filk.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CurrencyRateNbuDto {
+    @JsonProperty("cc")
+    private String currencyCode;
+
+    private double rate;
+}

--- a/src/main/java/com/filk/entity/Country.java
+++ b/src/main/java/com/filk/entity/Country.java
@@ -1,7 +1,7 @@
 package com.filk.entity;
 
 import com.fasterxml.jackson.annotation.JsonView;
-import com.filk.view.Views;
+import com.filk.util.Views;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;

--- a/src/main/java/com/filk/entity/Genre.java
+++ b/src/main/java/com/filk/entity/Genre.java
@@ -1,7 +1,7 @@
 package com.filk.entity;
 
 import com.fasterxml.jackson.annotation.JsonView;
-import com.filk.view.Views;
+import com.filk.util.Views;
 import lombok.*;
 
 

--- a/src/main/java/com/filk/entity/Movie.java
+++ b/src/main/java/com/filk/entity/Movie.java
@@ -1,7 +1,7 @@
 package com.filk.entity;
 
 import com.fasterxml.jackson.annotation.JsonView;
-import com.filk.view.Views;
+import com.filk.util.Views;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;

--- a/src/main/java/com/filk/entity/Review.java
+++ b/src/main/java/com/filk/entity/Review.java
@@ -1,7 +1,7 @@
 package com.filk.entity;
 
 import com.fasterxml.jackson.annotation.JsonView;
-import com.filk.view.Views;
+import com.filk.util.Views;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;

--- a/src/main/java/com/filk/entity/User.java
+++ b/src/main/java/com/filk/entity/User.java
@@ -1,7 +1,7 @@
 package com.filk.entity;
 
 import com.fasterxml.jackson.annotation.JsonView;
-import com.filk.view.Views;
+import com.filk.util.Views;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;

--- a/src/main/java/com/filk/service/CurrencyService.java
+++ b/src/main/java/com/filk/service/CurrencyService.java
@@ -1,0 +1,7 @@
+package com.filk.service;
+
+import com.filk.util.CurrencyCode;
+
+public interface CurrencyService {
+    double convert(double amount, CurrencyCode currencyCode);
+}

--- a/src/main/java/com/filk/service/MovieService.java
+++ b/src/main/java/com/filk/service/MovieService.java
@@ -1,7 +1,7 @@
 package com.filk.service;
 
 import com.filk.entity.Movie;
-import com.filk.entity.RequestParameters;
+import com.filk.util.RequestParameters;
 
 import java.util.List;
 
@@ -9,5 +9,5 @@ public interface MovieService {
     List<Movie> getAll(RequestParameters requestParameters);
     List<Movie> getRandom();
     List<Movie> getByGenre(int genreId, RequestParameters requestParameters);
-    Movie getById(int movieId);
+    Movie getById(int movieId, RequestParameters requestParameters);
 }

--- a/src/main/java/com/filk/service/impl/DefaultCurrencyService.java
+++ b/src/main/java/com/filk/service/impl/DefaultCurrencyService.java
@@ -1,0 +1,78 @@
+package com.filk.service.impl;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.filk.dto.CurrencyRateNbuDto;
+import com.filk.util.CurrencyCode;
+import com.filk.service.CurrencyService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.net.URL;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Slf4j
+public class DefaultCurrencyService implements CurrencyService {
+    @Value("${currency.ratesUrl}")
+    private String currencyRatesUrl;
+    private CurrencyCode defaultCurrency = CurrencyCode.UAH;
+    private volatile Map<CurrencyCode, Double> currencyRatesCache = new HashMap<>();
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    public DefaultCurrencyService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public double convert(double amount, CurrencyCode currencyCode) {
+        return BigDecimal.valueOf(amount).divide(BigDecimal.valueOf(currencyRatesCache.get(currencyCode)), 2, RoundingMode.HALF_UP).doubleValue();
+    }
+
+    @PostConstruct
+    @Scheduled(cron = "${currency.ratesUpdateCron}")
+    public void refreshCurrencyPrice() {
+        List<CurrencyRateNbuDto> currencies;
+        String formattedDate = LocalDateTime.now().minusDays(1).format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String requestUrl = String.format(currencyRatesUrl, formattedDate);
+
+        try {
+            currencies = objectMapper.readValue(new URL(requestUrl), new TypeReference<List<CurrencyRateNbuDto>>() {
+            });
+        } catch (IOException e) {
+            log.info("Not able to get currency rate list from {}", requestUrl);
+            return;
+        }
+
+        Map<CurrencyCode, Double> currencyRates = new HashMap<>();
+        currencyRates.put(defaultCurrency, 1.0);
+
+        for (CurrencyRateNbuDto currency : currencies) {
+            try {
+                currencyRates.put(CurrencyCode.valueOf(currency.getCurrencyCode()), currency.getRate());
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+
+        if (currencyRates.size() != CurrencyCode.values().length) {
+            log.info("Some currency rates have not been loaded.");
+            return;
+        }
+
+        currencyRatesCache = currencyRates;
+
+        log.info("Currency rates has been successfully refreshed.");
+    }
+}

--- a/src/main/java/com/filk/service/impl/DefaultMovieService.java
+++ b/src/main/java/com/filk/service/impl/DefaultMovieService.java
@@ -2,7 +2,8 @@ package com.filk.service.impl;
 
 import com.filk.dao.MovieDao;
 import com.filk.entity.Movie;
-import com.filk.entity.RequestParameters;
+import com.filk.util.RequestParameters;
+import com.filk.service.CurrencyService;
 import com.filk.service.MovieEnrichmentService;
 import com.filk.service.MovieService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,14 +16,16 @@ import java.util.List;
 public class DefaultMovieService implements MovieService {
     private MovieDao movieDao;
     private MovieEnrichmentService movieEnrichmentService;
+    private CurrencyService currencyService;
 
     @Value("${movie.randomCount}")
     private int randomCount;
 
     @Autowired
-    public DefaultMovieService(MovieDao movieDao, MovieEnrichmentService movieEnrichmentService) {
+    public DefaultMovieService(MovieDao movieDao, MovieEnrichmentService movieEnrichmentService, CurrencyService currencyService) {
         this.movieDao = movieDao;
         this.movieEnrichmentService = movieEnrichmentService;
+        this.currencyService = currencyService;
     }
 
     @Override
@@ -41,9 +44,11 @@ public class DefaultMovieService implements MovieService {
     }
 
     @Override
-    public Movie getById(int movieId) {
+    public Movie getById(int movieId, RequestParameters requestParameters) {
         Movie movie = movieDao.getById(movieId);
         movieEnrichmentService.enrich(movie);
+
+        movie.setPrice(currencyService.convert(movie.getPrice(), requestParameters.getCurrency()));
 
         return movie;
     }

--- a/src/main/java/com/filk/util/CurrencyCode.java
+++ b/src/main/java/com/filk/util/CurrencyCode.java
@@ -1,7 +1,27 @@
 package com.filk.util;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public enum CurrencyCode {
     UAH,
     USD,
-    EUR
+    EUR;
+
+    public static boolean contains(String code) {
+        for (CurrencyCode value : CurrencyCode.values()) {
+            if(value.toString().equals(code)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static List<String> getStringList() {
+        List<String> list = new ArrayList<>();
+        for (CurrencyCode code : CurrencyCode.values()) {
+            list.add(code.toString());
+        }
+        return list;
+    }
 }

--- a/src/main/java/com/filk/util/CurrencyCode.java
+++ b/src/main/java/com/filk/util/CurrencyCode.java
@@ -1,0 +1,7 @@
+package com.filk.util;
+
+public enum CurrencyCode {
+    UAH,
+    USD,
+    EUR
+}

--- a/src/main/java/com/filk/util/RequestParameters.java
+++ b/src/main/java/com/filk/util/RequestParameters.java
@@ -1,4 +1,4 @@
-package com.filk.entity;
+package com.filk.util;
 
 import lombok.Getter;
 
@@ -8,6 +8,7 @@ import java.util.Objects;
 public class RequestParameters {
     private SortBy sortBy;
     private SortOrder sortOrder;
+    private CurrencyCode currency;
 
     public enum SortBy {
         RATING,
@@ -27,6 +28,10 @@ public class RequestParameters {
         this.sortOrder = SortOrder.valueOf(sortOrder.toUpperCase());
     }
 
+    public void setCurrency(String currency) {
+        this.currency = CurrencyCode.valueOf(currency.toUpperCase());
+    }
+
     private void validate() {
         if(sortBy == SortBy.RATING && sortOrder == SortOrder.ASC) {
             throw new IllegalArgumentException("Sort by rating ASC is not supported.");
@@ -39,6 +44,9 @@ public class RequestParameters {
         }
         if(sortBy == SortBy.PRICE && sortOrder == null) {
             sortOrder = SortOrder.ASC;
+        }
+        if(currency == null) {
+            currency = CurrencyCode.UAH;
         }
     }
 

--- a/src/main/java/com/filk/util/Views.java
+++ b/src/main/java/com/filk/util/Views.java
@@ -1,4 +1,4 @@
-package com.filk.view;
+package com.filk.util;
 
 public class Views {
     public static class Base {

--- a/src/main/java/com/filk/web/controller/MovieController.java
+++ b/src/main/java/com/filk/web/controller/MovieController.java
@@ -3,9 +3,9 @@ package com.filk.web.controller;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.filk.entity.Movie;
 
-import com.filk.entity.RequestParameters;
+import com.filk.util.RequestParameters;
 import com.filk.service.MovieService;
-import com.filk.view.Views;
+import com.filk.util.Views;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -45,7 +45,8 @@ public class MovieController {
 
     @GetMapping("{movieId}")
     @JsonView(Views.MovieDetail.class)
-    public Movie getMovieById(@PathVariable int movieId) {
-        return movieService.getById(movieId);
+    public Movie getMovieById(@PathVariable int movieId,
+                              RequestParameters requestParameters) {
+        return movieService.getById(movieId, requestParameters.postProcess());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,10 @@ movie:
 genre:
   cacheUpdatePeriod: 14400000 # 4 * 60 * 60 * 1000 = 4 hours
 
+currency:
+  ratesUpdateCron: 0 0 17 * * * # On 17:00 each day
+  ratesUrl: https://bank.gov.ua/NBUStatService/v1/statdirectory/exchange?json&date=%s
+
 logger:
   fileName: movieland
   logLevelFile: DEBUG

--- a/src/main/resources/root-context.xml
+++ b/src/main/resources/root-context.xml
@@ -37,5 +37,4 @@
     </bean>
 
     <bean id="restTemplate" class="org.springframework.web.client.RestTemplate"/>
-    <bean id="reentrantLock" class="java.util.concurrent.locks.ReentrantLock"/>
 </beans>

--- a/src/main/resources/root-context.xml
+++ b/src/main/resources/root-context.xml
@@ -35,4 +35,6 @@
         <property name="initialSize" value="${db.jdbc.initialSize}"/>
         <property name="maxTotal" value="${db.jdbc.maxTotal}"/>
     </bean>
+
+    <bean id="objectMapper" class="com.fasterxml.jackson.databind.ObjectMapper"/>
 </beans>

--- a/src/main/resources/root-context.xml
+++ b/src/main/resources/root-context.xml
@@ -36,5 +36,6 @@
         <property name="maxTotal" value="${db.jdbc.maxTotal}"/>
     </bean>
 
-    <bean id="objectMapper" class="com.fasterxml.jackson.databind.ObjectMapper"/>
+    <bean id="restTemplate" class="org.springframework.web.client.RestTemplate"/>
+    <bean id="reentrantLock" class="java.util.concurrent.locks.ReentrantLock"/>
 </beans>

--- a/src/test/java/com/filk/dao/jdbc/JdbcMovieDaoTest.java
+++ b/src/test/java/com/filk/dao/jdbc/JdbcMovieDaoTest.java
@@ -2,7 +2,7 @@ package com.filk.dao.jdbc;
 
 import com.filk.dao.MovieDao;
 import com.filk.entity.Movie;
-import com.filk.entity.RequestParameters;
+import com.filk.util.RequestParameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/filk/service/impl/DefaultCurrencyServiceTest.java
+++ b/src/test/java/com/filk/service/impl/DefaultCurrencyServiceTest.java
@@ -1,0 +1,44 @@
+package com.filk.service.impl;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.filk.dto.CurrencyRateNbuDto;
+import com.filk.util.CurrencyCode;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DefaultCurrencyServiceTest {
+
+    @Test
+    public void convert() throws IOException, NoSuchFieldException, IllegalAccessException {
+        ObjectMapper objectMapperMock = mock(ObjectMapper.class);
+        DefaultCurrencyService defaultCurrencyService = new DefaultCurrencyService(objectMapperMock);
+
+        Field currencyRatesUrl = defaultCurrencyService.getClass().getDeclaredField("currencyRatesUrl");
+        currencyRatesUrl.setAccessible(true);
+        currencyRatesUrl.set(defaultCurrencyService, "https://bank.gov.ua");
+        currencyRatesUrl.setAccessible(false);
+
+        List<CurrencyRateNbuDto> currencyRates = new ArrayList<>();
+        currencyRates.add(new CurrencyRateNbuDto("USD", 27.5));
+        currencyRates.add(new CurrencyRateNbuDto("EUR", 31.2));
+
+        when(objectMapperMock.readValue(any(URL.class), any(TypeReference.class))).thenReturn(currencyRates);
+
+        defaultCurrencyService.refreshCurrencyPrice();
+
+        assertEquals(3.94, defaultCurrencyService.convert(123, CurrencyCode.EUR), 0.01);
+        assertEquals(4.47, defaultCurrencyService.convert(123, CurrencyCode.USD), 0.01);
+        assertEquals(123, defaultCurrencyService.convert(123, CurrencyCode.UAH), 0.01);
+    }
+}

--- a/src/test/java/com/filk/service/impl/DefaultCurrencyServiceTest.java
+++ b/src/test/java/com/filk/service/impl/DefaultCurrencyServiceTest.java
@@ -17,7 +17,7 @@ public class DefaultCurrencyServiceTest {
     @Test
     public void convert() {
         RestTemplate restTemplateMock = mock(RestTemplate.class);
-        DefaultCurrencyService defaultCurrencyService = new DefaultCurrencyService(restTemplateMock, new ReentrantLock());
+        DefaultCurrencyService defaultCurrencyService = new DefaultCurrencyService(restTemplateMock);
 
         defaultCurrencyService.setCurrencyRatesUrl("https://bank.gov.ua/NBUStatService/v1/statdirectory/exchange?json&date=%s");
 

--- a/src/test/java/com/filk/service/impl/DefaultCurrencyServiceTest.java
+++ b/src/test/java/com/filk/service/impl/DefaultCurrencyServiceTest.java
@@ -1,16 +1,11 @@
 package com.filk.service.impl;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.filk.dto.CurrencyRateNbuDto;
 import com.filk.util.CurrencyCode;
 import org.junit.Test;
+import org.springframework.web.client.RestTemplate;
 
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -20,20 +15,17 @@ import static org.mockito.Mockito.when;
 public class DefaultCurrencyServiceTest {
 
     @Test
-    public void convert() throws IOException, NoSuchFieldException, IllegalAccessException {
-        ObjectMapper objectMapperMock = mock(ObjectMapper.class);
-        DefaultCurrencyService defaultCurrencyService = new DefaultCurrencyService(objectMapperMock);
+    public void convert() {
+        RestTemplate restTemplateMock = mock(RestTemplate.class);
+        DefaultCurrencyService defaultCurrencyService = new DefaultCurrencyService(restTemplateMock, new ReentrantLock());
 
-        Field currencyRatesUrl = defaultCurrencyService.getClass().getDeclaredField("currencyRatesUrl");
-        currencyRatesUrl.setAccessible(true);
-        currencyRatesUrl.set(defaultCurrencyService, "https://bank.gov.ua");
-        currencyRatesUrl.setAccessible(false);
+        defaultCurrencyService.setCurrencyRatesUrl("https://bank.gov.ua/NBUStatService/v1/statdirectory/exchange?json&date=%s");
 
-        List<CurrencyRateNbuDto> currencyRates = new ArrayList<>();
-        currencyRates.add(new CurrencyRateNbuDto("USD", 27.5));
-        currencyRates.add(new CurrencyRateNbuDto("EUR", 31.2));
+        CurrencyRateNbuDto[] currencyRates = new CurrencyRateNbuDto[2];
+        currencyRates[0] = new CurrencyRateNbuDto("USD", 27.5);
+        currencyRates[1] = new CurrencyRateNbuDto("EUR", 31.2);
 
-        when(objectMapperMock.readValue(any(URL.class), any(TypeReference.class))).thenReturn(currencyRates);
+        when(restTemplateMock.getForObject(any(String.class), any(Class.class))).thenReturn(currencyRates);
 
         defaultCurrencyService.refreshCurrencyPrice();
 

--- a/src/test/java/com/filk/web/controller/MovieControllerTest.java
+++ b/src/test/java/com/filk/web/controller/MovieControllerTest.java
@@ -2,6 +2,7 @@ package com.filk.web.controller;
 
 import com.filk.entity.*;
 import com.filk.service.MovieService;
+import com.filk.util.RequestParameters;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -171,7 +172,7 @@ public class MovieControllerTest {
 
     @Test
     public void getMovieByIdJson() throws Exception {
-        when(movieServiceMock.getById(33)).thenReturn(movies.get(0));
+        when(movieServiceMock.getById(33, new RequestParameters())).thenReturn(movies.get(0));
 
         mockMvc.perform(get("/movie/33"))
                 .andDo(print())

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -15,6 +15,10 @@ movie:
 genre:
   cacheUpdatePeriod: 14400000 # 4 * 60 * 60 * 1000 = 4 hours
 
+currency:
+  ratesUpdateCron: 0 0 17 * * * # On 17:00 each day
+  ratesUrl: https://bank.gov.ua/NBUStatService/v1/statdirectory/exchange?json&date=%s
+
 logger:
   fileName: movieland
   logLevelFile: DEBUG


### PR DESCRIPTION
While sending requests to get movie by id [b-6], user should be able to add parameter with currency in order to receive movie price in selected currency.
1. In DB, all prices are stored in UAH.
2. Price can be converted to USD or EUR.
3. For example, /v1/movie/{movieId}?currency=USD.
4. Prices should be converted according to today NBU rate.
5. By default, selected currency is UAH.

+ Tests